### PR TITLE
Fix missing minimum NAV validation

### DIFF
--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -1,3 +1,5 @@
+use std::cmp::max;
+
 use anchor_lang::prelude::{borsh::de, *};
 
 use crate::{constants::{MAX_FEE, ONE_BITCOIN}, errors::SolvError};
@@ -183,7 +185,7 @@ impl Vault {
             .ok_or(ProgramError::ArithmeticOverflow)?
             .try_into()
             .map_err(|_| ProgramError::ArithmeticOverflow)?;
-        let amount = amount.checked_sub(fee).ok_or(ProgramError::ArithmeticOverflow)?;
+        let amount = amount.checked_sub(max(fee, 1)).ok_or(ProgramError::ArithmeticOverflow)?;
         Ok((amount, fee))
     }
 

--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -165,6 +165,7 @@ impl Vault {
         let min_nav = self.nav.checked_sub(nav_diff).ok_or(ProgramError::ArithmeticOverflow)?;
         require_gte!(max_nav, nav, SolvError::InvalidNAVValue);
         require_gte!(nav, min_nav, SolvError::InvalidNAVValue);
+        require_gte!(nav, ONE_BITCOIN, SolvError::InvalidNAVValue);
         self.nav = nav;
         self.update()
     }


### PR DESCRIPTION
Current implementation of `vault_set_nav` instruction does not prevent new NAV values from being updated to be below the base value (10^8), which would fail one of the test cases.

Although rare and unlikely, this change would prevent oracle managers from updating a vault's NAV to reflect below the initial base NAV value, leading to potential inaccuracies in vault performance tracking.

Ideally, the minimum NAV should be any unsigned positive integer, but I will leave this up to the team's discretion.