### PR TITLE
Sign vault

### DIFF
--- a/programs/solvbtc/src/constants.rs
+++ b/programs/solvbtc/src/constants.rs
@@ -2,53 +2,11 @@ use anchor_lang::prelude::*;
 
 pub const ONE_BITCOIN: u64 = 100_000_000;
 pub const FREEZE_PERIOD: i64 = 86400;
+pub const DELTA: u128 = 5;
 pub const ADMIN_WHITELIST: &[Pubkey] = &[
     Pubkey::from_str_const("BsF2mR9brTd7u7wGWrejksQzsdrGFNcddRSYeNpHZixM")
 ];
 
 pub const MAX_FEE: u16 = 10_000;
 
-/* Mints */
-// pub const SOLV_MINT: ([u8; 32], u8) =
-//     const_crypto::ed25519::derive_program_address(&[b"solv"], crate::ID_CONST.as_array());
-// pub const SOLV_MINT_AUTH: Pubkey = Pubkey::new_from_array(SOLV_MINT.0);
-// pub const SOLV_MINT_AUTH_BUMP: [u8; 1] = [SOLV_MINT.1];
 
-// pub const POOL_SIGNER_SEED: &[u8] = b"ccip_tokenpool_signer";
-// pub const TOKENPOOL_PROGRAM_ID: Pubkey = pubkey!("ECvqYduigrFHeAU1kFCkehiiQz9eaeddUz6gH7BfD7AL");
-
-// pub const SOLV_BTC: Pubkey = pubkey!("SoLvHDFVstC74Jr9eNLTDoG4goSUsn1RENmjNtFKZvW");
-// pub const X_SOLV_BTC: Pubkey = pubkey!("SoLvAiHLF7LGEaiTN5KGZt1bNnraoWTi5mjcvRoDAX4");
-// pub const SOLV_BTC_JUP: Pubkey = pubkey!("SoLvzL3ZVjofmNB5LYFrf94QtNhMUSea4DawFhnAau8");
-
-// HEoPcCuuHzvxBNjfG5i8jjCDqf8RsPyhuWQtE5oRSFYn
-// pub const SOLV_BTC_POOL: ([u8; 32], u8) = const_crypto::ed25519::derive_program_address(
-//     &[POOL_SIGNER_SEED, SOLV_BTC.as_array()],
-//     TOKENPOOL_PROGRAM_ID.as_array(),
-// );
-// pub const SOLV_BTC_POOL_AUTH: Pubkey = Pubkey::new_from_array(SOLV_BTC_POOL.0);
-// pub const SOLV_BTC_POOL_AUTH_BUMP: [u8; 1] = [SOLV_BTC_POOL.1];
-
-// DcUZY1UdSc5mFT97wvfcDu7PB7ax5XJN62efdb4F6eW6
-// pub const X_SOLV_BTC_POOL: ([u8; 32], u8) = const_crypto::ed25519::derive_program_address(
-//     &[POOL_SIGNER_SEED, X_SOLV_BTC.as_array()],
-//     TOKENPOOL_PROGRAM_ID.as_array(),
-// );
-// pub const X_SOLV_BTC_POOL_AUTH: Pubkey = Pubkey::new_from_array(X_SOLV_BTC_POOL.0);
-// pub const X_SOLV_BTC_POOL_AUTH_BUMP: [u8; 1] = [X_SOLV_BTC_POOL.1];
-
-// DbM3ixNXZ3BjvKNZANzXKjYh2ZywjyUoaB4uL7QmRkd7
-// pub const SOLV_BTC_JUP_POOL: ([u8; 32], u8) = const_crypto::ed25519::derive_program_address(
-//     &[POOL_SIGNER_SEED, SOLV_BTC_JUP.as_array()],
-//     TOKENPOOL_PROGRAM_ID.as_array(),
-// );
-// pub const SOLV_BTC_JUP_POOL_AUTH: Pubkey = Pubkey::new_from_array(SOLV_BTC_JUP_POOL.0);
-// pub const SOLV_BTC_JUP_POOL_AUTH_BUMP: [u8; 1] = [SOLV_BTC_JUP_POOL.1];
-
-// #[test]
-// fn get_key() {
-//     println!("{}", SOLV_MINT_AUTH.to_string());
-//     println!("{}", SOLV_BTC_POOL_AUTH.to_string());
-//     println!("{}", X_SOLV_BTC_POOL_AUTH.to_string());
-//     println!("{}", SOLV_BTC_JUP_POOL_AUTH.to_string());
-// }

--- a/programs/solvbtc/src/constants.rs
+++ b/programs/solvbtc/src/constants.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 
 pub const ONE_BITCOIN: u64 = 100_000_000;
+pub const FREEZE_PERIOD: i64 = 86400;
 pub const ADMIN_WHITELIST: &[Pubkey] = &[
     Pubkey::from_str_const("BsF2mR9brTd7u7wGWrejksQzsdrGFNcddRSYeNpHZixM")
 ];

--- a/programs/solvbtc/src/contexts/minter_manager_mint.rs
+++ b/programs/solvbtc/src/contexts/minter_manager_mint.rs
@@ -6,9 +6,8 @@ use anchor_spl::token_interface::{
 
 #[derive(Accounts)]
 pub struct MinterManagerMint<'info> {
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    /// Separate authority from payer to support multisig and PDA signers
+
+
     pub authority: Signer<'info>,
     #[account(mut)]
     pub mint: InterfaceAccount<'info, Mint>,

--- a/programs/solvbtc/src/contexts/minter_manager_transfer_admin.rs
+++ b/programs/solvbtc/src/contexts/minter_manager_transfer_admin.rs
@@ -3,9 +3,7 @@ use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct MinterManagerTransferAdmin<'info> {
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    /// Separate authority from payer to support multisig and PDA signers
+
     pub admin: Signer<'info>,
     #[account(
         mut,

--- a/programs/solvbtc/src/contexts/minter_manager_update_minter.rs
+++ b/programs/solvbtc/src/contexts/minter_manager_update_minter.rs
@@ -3,9 +3,7 @@ use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
 pub struct MinterManagerUpdateMinter<'info> {
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    /// Separate authority from payer to support multisig and PDA signers
+
     pub admin: Signer<'info>,
     #[account(
         mut,

--- a/programs/solvbtc/src/contexts/vault_deposit.rs
+++ b/programs/solvbtc/src/contexts/vault_deposit.rs
@@ -63,7 +63,7 @@ impl<'info> VaultDeposit<'info> {
     }
 
     pub fn mint_target_tokens(&mut self, amount: u64, min_amount_out: u64) -> Result<()> {
-        let (mint_amount, fee_amount) = Vault::calculate_fee(self.vault.shares_from_deposit(amount)?, self.vault.deposit_fee(&self.mint_token.key())?)?;
+        let (mint_amount, fee_amount) = Vault::calculate_fee(self.vault.shares_from_deposit(amount)?, self.vault.get_deposit_fee(&self.mint_token.key())?)?;
 
         // Slippage protection
         require_gte!(mint_amount, min_amount_out, SolvError::SlippageExceeded);

--- a/programs/solvbtc/src/contexts/vault_deposit.rs
+++ b/programs/solvbtc/src/contexts/vault_deposit.rs
@@ -1,5 +1,5 @@
 use crate::{errors::SolvError, events::DepositEvent, helpers::{mint_to_checked_1_of_n_multisig, MintToChecked1ofNMultisig}, state::Vault};
-use anchor_lang::{prelude::*, solana_program::last_restart_slot::LastRestartSlot};
+use anchor_lang::{prelude::*};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token_interface::{
@@ -55,9 +55,7 @@ impl<'info> VaultDeposit<'info> {
             to: self.treasurer_token_ta.to_account_info(),
             authority: self.user.to_account_info(),
         };
-        let clock = Clock::get()?;
-        let last_restart = LastRestartSlot::get()?;
-        require_gte!(clock.slot, last_restart.last_restart_slot);
+
 
         let ctx = CpiContext::new(self.token_program.to_account_info(), accounts);
 

--- a/programs/solvbtc/src/contexts/vault_deposit.rs
+++ b/programs/solvbtc/src/contexts/vault_deposit.rs
@@ -1,5 +1,5 @@
 use crate::{errors::SolvError, events::DepositEvent, helpers::{mint_to_checked_1_of_n_multisig, MintToChecked1ofNMultisig}, state::Vault};
-use anchor_lang::prelude::*;
+use anchor_lang::{prelude::*, solana_program::last_restart_slot::LastRestartSlot};
 use anchor_spl::{
     associated_token::AssociatedToken,
     token_interface::{
@@ -10,7 +10,7 @@ use anchor_spl::{
 
 #[derive(Accounts)]
 pub struct VaultDeposit<'info> {
-    #[account(mut)]
+
     pub user: Signer<'info>,
     #[account(
         mut,
@@ -37,7 +37,7 @@ pub struct VaultDeposit<'info> {
     #[account(mut)]
     pub mint_target: Box<InterfaceAccount<'info, Mint>>,
     #[account(
-        mut,
+
         seeds = [b"vault", mint_target.key().as_ref()],
         bump = vault.bump,
         constraint = vault.is_whitelisted(&mint_token.key()),
@@ -55,6 +55,9 @@ impl<'info> VaultDeposit<'info> {
             to: self.treasurer_token_ta.to_account_info(),
             authority: self.user.to_account_info(),
         };
+        let clock = Clock::get()?;
+        let last_restart = LastRestartSlot::get()?;
+        require_gte!(clock.slot, last_restart.last_restart_slot);
 
         let ctx = CpiContext::new(self.token_program.to_account_info(), accounts);
 

--- a/programs/solvbtc/src/contexts/vault_oracle_update.rs
+++ b/programs/solvbtc/src/contexts/vault_oracle_update.rs
@@ -1,4 +1,4 @@
-use crate::{errors::SolvError, state::Vault};
+use crate::{errors::SolvError, state::Vault, constants::ONE_BITCOIN};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -11,6 +11,7 @@ pub struct VaultOracleUpdate<'info> {
 impl<'info> VaultOracleUpdate<'info> {
     pub fn set_nav(&mut self, nav: u64) -> Result<()> {
         require_keys_eq!(self.vault.oracle_manager, self.oracle_manager.key(), SolvError::InvalidAddress);
+        require_gte!(nav, ONE_BITCOIN, SolvError::InvalidNAVValue);
         self.vault.set_nav(nav)
     }
     

--- a/programs/solvbtc/src/contexts/vault_request_withdraw.rs
+++ b/programs/solvbtc/src/contexts/vault_request_withdraw.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::SolvError, state::{Vault, WithdrawRequest}
+    errors::SolvError, state::{Vault, WithdrawRequestV2}
 };
 use anchor_lang::prelude::*;
 use anchor_spl::{
@@ -30,7 +30,7 @@ pub struct VaultRequestWithdraw<'info> {
     #[account(
         init,
         payer = user,
-        space = WithdrawRequest::DISCRIMINATOR.len() + WithdrawRequest::INIT_SPACE,
+        space = WithdrawRequestV2::DISCRIMINATOR.len() + WithdrawRequestV2::INIT_SPACE,
         seeds = [
             b"withdraw_request", 
             vault.key().as_ref(),
@@ -40,7 +40,7 @@ pub struct VaultRequestWithdraw<'info> {
         ],
         bump,
     )]
-    pub withdraw_request: Account<'info, WithdrawRequest>,
+    pub withdraw_request: Account<'info, WithdrawRequestV2>,
     #[account(
         mut,
         seeds = [b"vault", mint_target.key().as_ref()],

--- a/programs/solvbtc/src/contexts/vault_request_withdraw.rs
+++ b/programs/solvbtc/src/contexts/vault_request_withdraw.rs
@@ -49,7 +49,6 @@ pub struct VaultRequestWithdraw<'info> {
     )]
     pub vault: Account<'info, Vault>,
     pub token_program: Interface<'info, TokenInterface>,
-    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
 

--- a/programs/solvbtc/src/contexts/vault_request_withdraw.rs
+++ b/programs/solvbtc/src/contexts/vault_request_withdraw.rs
@@ -87,6 +87,7 @@ impl<'info> VaultRequestWithdraw<'info> {
             shares,
             request_hash,
             self.vault.nav,
+            self.vault.mint,
         )
     }
 }

--- a/programs/solvbtc/src/contexts/vault_update.rs
+++ b/programs/solvbtc/src/contexts/vault_update.rs
@@ -4,8 +4,7 @@ use anchor_spl::token_interface::Mint;
 
 #[derive(Accounts)]
 pub struct VaultUpdate<'info> {
-    #[account(mut)]
-    pub payer: Signer<'info>,
+
     /// Separate authority from payer to support multisig and PDA signers
     pub admin: Signer<'info>,
     pub mint: InterfaceAccount<'info, Mint>,
@@ -16,7 +15,6 @@ pub struct VaultUpdate<'info> {
         bump = vault.bump
     )]
     pub vault: Account<'info, Vault>,
-    pub system_program: Program<'info, System>,
 }
 
 impl<'info> VaultUpdate<'info> {

--- a/programs/solvbtc/src/contexts/vault_withdraw.rs
+++ b/programs/solvbtc/src/contexts/vault_withdraw.rs
@@ -1,5 +1,5 @@
 use crate::events::WithdrawEvent;
-use crate::state::{Vault, WithdrawRequest};
+use crate::state::{Vault, WithdrawRequest, WithdrawRequestV2};
 use crate::errors::SolvError;
 use anchor_lang::prelude::*;
 use anchor_spl::{
@@ -129,6 +129,80 @@ impl<'info> VaultWithdraw<'info> {
             withdraw_amount:amount, 
             withdraw_token: self.mint_withdraw.key(), 
             request_hash: withdraw_request.request_hash, 
+            withdraw_fee: fee,
+        });
+
+        Ok(())
+    }
+
+    pub fn withdraw_tokens_v2(&mut self, signature: [u8;64]) -> Result<()> {
+        // Get withdraw request
+        let mut withdraw_request_data = &self.withdraw_request.data.borrow()[..];
+        let withdraw_request = WithdrawRequestV2::try_deserialize(&mut withdraw_request_data)?;
+
+        // Verify withdraw account address;
+        if self.user_withdraw_ta.key().ne(&withdraw_request.withdraw_token_account) {
+            return Err(SolvError::InvalidAddress)?;
+        }
+
+        // Verify signature
+        withdraw_request.verify_eip191(Secp256k1EcdsaSignature(signature), self.vault.verifier)?;
+
+        // Check 1.01*nav >= nav of withdraw request
+        let nav_diff: u64 = u64::try_from(u128::from(self.vault.nav)
+            .checked_mul(100 as u128)
+            .ok_or(ProgramError::ArithmeticOverflow)?
+            .checked_div(MAX_FEE.into())
+            .ok_or(ProgramError::ArithmeticOverflow)?)
+            .map_err(|_| ProgramError::ArithmeticOverflow)?;
+        let max_nav = self.vault.nav.checked_add(nav_diff).ok_or(ProgramError::ArithmeticOverflow)?;
+        require_gte!(max_nav, withdraw_request.nav, SolvError::NAVExceeded);
+
+        // Get withdraw amount and withdraw fee
+        let (amount, fee) = Vault::calculate_fee(withdraw_request.withdraw_amount, self.vault.withdraw_fee)?;
+        msg!("Withdraw amount: {}, Fee: {}", amount, fee);
+
+        // Signer seeds
+        let key = self.vault.mint.key();
+        let bump = [self.vault.bump];
+        let signer_seeds: [&[&[u8]]; 1] = [&[b"vault", key.as_ref(), bump.as_ref()]];
+        // Withdraw fee
+        let accounts = TransferChecked {
+            from: self.vault_withdraw_ta.to_account_info(),
+            to: self.fee_receiver_ta.to_account_info(),
+            mint: self.mint_withdraw.to_account_info(),
+            authority: self.vault.to_account_info(),
+        };
+
+        let ctx = CpiContext::new_with_signer(
+            self.token_program.to_account_info(),
+            accounts,
+            &signer_seeds,
+        );
+
+        transfer_checked(ctx, fee, self.mint_withdraw.decimals)?;
+
+        // Withdraw amount
+        let accounts = TransferChecked {
+            from: self.vault_withdraw_ta.to_account_info(),
+            to: self.user_withdraw_ta.to_account_info(),
+            mint: self.mint_withdraw.to_account_info(),
+            authority: self.vault.to_account_info(),
+        };
+
+        let ctx = CpiContext::new_with_signer(
+            self.token_program.to_account_info(),
+            accounts,
+            &signer_seeds,
+        );
+
+        transfer_checked(ctx, amount, self.mint_withdraw.decimals)?;
+
+        emit!(WithdrawEvent {
+            user: self.user.key(),
+            withdraw_amount:amount,
+            withdraw_token: self.mint_withdraw.key(),
+            request_hash: withdraw_request.request_hash,
             withdraw_fee: fee,
         });
 

--- a/programs/solvbtc/src/errors.rs
+++ b/programs/solvbtc/src/errors.rs
@@ -30,4 +30,7 @@ pub enum SolvError {
     MathOverflow,
     #[msg("SolvOracle: Invalid Max NAV Change - must be <=10,000")]
     InvalidMaxNavChange,
+    #[msg("SolvOracle: Nav update too frequently")]
+    NavUpdateTooFrequent
+
 }

--- a/programs/solvbtc/src/events/mod.rs
+++ b/programs/solvbtc/src/events/mod.rs
@@ -12,6 +12,18 @@ pub struct WithdrawRequestEvent {
 }
 
 #[event]
+pub struct WithdrawRequestEventV2 {
+    pub user: Pubkey,
+    pub withdraw_token: Pubkey,
+    pub withdraw_amount: u64,
+    pub token: Pubkey,
+    pub shares: u64,
+    pub request_hash: [u8; 32],
+    pub nav: u64,
+    pub slot: u64,
+}
+
+#[event]
 pub struct WithdrawEvent {
     pub user: Pubkey,
     pub withdraw_token: Pubkey,

--- a/programs/solvbtc/src/events/mod.rs
+++ b/programs/solvbtc/src/events/mod.rs
@@ -20,7 +20,7 @@ pub struct WithdrawRequestEventV2 {
     pub shares: u64,
     pub request_hash: [u8; 32],
     pub nav: u64,
-    pub slot: u64,
+    pub mint: Pubkey,
 }
 
 #[event]

--- a/programs/solvbtc/src/helpers.rs
+++ b/programs/solvbtc/src/helpers.rs
@@ -29,7 +29,7 @@ pub fn mint_to_checked_1_of_n_multisig<'info>(
     )?;
     anchor_lang::solana_program::program::invoke_signed(
         &ix,
-        &[ctx.accounts.to, ctx.accounts.mint, ctx.accounts.multisig, ctx.accounts.signer],
+        &[ctx.accounts.mint, ctx.accounts.to, ctx.accounts.multisig, ctx.accounts.signer],
         ctx.signer_seeds,
     )
     .map_err(Into::into)

--- a/programs/solvbtc/src/lib.rs
+++ b/programs/solvbtc/src/lib.rs
@@ -31,7 +31,7 @@ pub mod solvbtc {
         ctx.accounts.mint_target_tokens(amount, min_amount_out)
     }
 
-    // withdraw_request(shares, request hash)
+    // vault_withdraw_request(shares, request hash)
     // Check request hash has not been requested or withdrawn. Apply a second hash as the key instead of using the request hash directly, for security purposes.
     // The second hash includes (user, withdraw token address,request hash, shares, NAV)
     // Record the second hash (hash, status)
@@ -182,7 +182,7 @@ pub mod solvbtc {
     }
 
     #[instruction(discriminator = 18)]
-    #[doc = "# Transfer Minter Manager Admin\nEnable admin to transfer admin priveleges to a new address."]
+    #[doc = "# Transfer Minter Manager Admin\nEnable admin to transfer admin privileges to a new address."]
     pub fn minter_manager_transfer_admin(
         ctx: Context<MinterManagerTransferAdmin>,
         admin: Pubkey,

--- a/programs/solvbtc/src/lib.rs
+++ b/programs/solvbtc/src/lib.rs
@@ -189,4 +189,15 @@ pub mod solvbtc {
     ) -> Result<()> {
         ctx.accounts.transfer_admin(admin)
     }
+
+    #[instruction(discriminator = 19)]
+    #[doc = "# Withdraw\nEnable user to process a withdrawal with a signed withdraw request v2."]
+    pub fn vault_withdraw_v2(
+        ctx: Context<VaultWithdraw>,
+        _hash: [u8; 32],
+        signature: [u8; 64],
+    ) -> Result<()> {
+        ctx.accounts.withdraw_tokens_v2(signature)?;
+        ctx.accounts.close_request_account()
+    }
 }

--- a/programs/solvbtc/src/lib.rs
+++ b/programs/solvbtc/src/lib.rs
@@ -18,7 +18,7 @@ pub mod solvbtc {
 
     // SolvBTC Vault Instructions
     //
-    // These instructions enable the creation of Solv vaults by the contract admint.
+    // These instructions enable the creation of Solv vaults by the contract admin.
     // These vaults are used to accept user deposits and handle withdrawals.
     #[instruction(discriminator = 0)]
     #[doc = "# Deposit\nEnable user to deposit accepted deposit tokens to a Solv vault and mint target token in return based upon pro-rata share of NAV."]
@@ -36,7 +36,7 @@ pub mod solvbtc {
     // The second hash includes (user, withdraw token address,request hash, shares, NAV)
     // Record the second hash (hash, status)
     // User transfer target token to vault, vault burn the token
-    // emit event  WithdrawRequest(user, withdraw token, shares  token address, shares, request hash, current NAV)
+    // emit event  WithdrawRequest(user, withdraw token, amount,  token address, shares, request hash, current NAV)
     #[instruction(discriminator = 1)]
     #[doc = "# Withdraw Request\nEnable user to request a withdrawal in a certain currency and record it onchain."]
     pub fn vault_withdraw_request(

--- a/programs/solvbtc/src/state/minter_manager.rs
+++ b/programs/solvbtc/src/state/minter_manager.rs
@@ -41,7 +41,7 @@ impl MinterManager {
         if let Some(empty_index) = self
             .minters
             .iter()
-            .position(|&pubkey| pubkey == Pubkey::default())
+            .position(|&pubkey| pubkey.eq(&Pubkey::default()))
         {
             // Check if the minter already exists in the occupied slots (0..empty_index)
             if self.minters[0..empty_index].contains(&minter) {
@@ -64,7 +64,7 @@ impl MinterManager {
         }
 
         // Find the minter, if it exists
-        if let Some(index) = self.minters.iter().position(|&pubkey| pubkey == minter) {
+        if let Some(index) = self.minters.iter().position(|&pubkey| pubkey.eq(&minter)) {
             // Shift all elements after the found index down by one position
             for i in index..self.minters.len() - 1 {
                 self.minters[i] = self.minters[i + 1];

--- a/programs/solvbtc/src/state/minter_manager.rs
+++ b/programs/solvbtc/src/state/minter_manager.rs
@@ -65,7 +65,7 @@ impl MinterManager {
 
         // Find the minter, if it exists
         if let Some(index) = self.minters.iter().position(|&pubkey| pubkey == minter) {
-            // Shift all elements after the found index up by one position
+            // Shift all elements after the found index down by one position
             for i in index..self.minters.len() - 1 {
                 self.minters[i] = self.minters[i + 1];
             }

--- a/programs/solvbtc/src/state/minter_manager.rs
+++ b/programs/solvbtc/src/state/minter_manager.rs
@@ -13,6 +13,9 @@ pub struct MinterManager {
 
 impl MinterManager {
     pub fn initialize(&mut self, admin: Pubkey, bump: u8) -> Result<()> {
+        if admin.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
         self.admin = admin;
         self.bump = bump;
         self.update()
@@ -55,12 +58,12 @@ impl MinterManager {
     }
 
     pub fn remove_minter(&mut self, minter: Pubkey) -> Result<()> {
-        // Ensure we are not trying to add a null address
+        // Ensure we are not trying to remove a null address
         if minter.eq(&Pubkey::default()) {
             return Err(SolvError::InvalidAddress.into());
         }
 
-        // Find the first instance of the minter
+        // Find the minter, if it exists
         if let Some(index) = self.minters.iter().position(|&pubkey| pubkey == minter) {
             // Shift all elements after the found index up by one position
             for i in index..self.minters.len() - 1 {

--- a/programs/solvbtc/src/state/mod.rs
+++ b/programs/solvbtc/src/state/mod.rs
@@ -6,3 +6,6 @@ pub use minter_manager::*;
 
 pub mod withdraw_request;
 pub use withdraw_request::*;
+
+pub mod withdraw_request_v2;
+pub use withdraw_request_v2::*;

--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -187,6 +187,7 @@ impl Vault {
         let min_nav = self.nav.checked_sub(nav_diff).ok_or(ProgramError::ArithmeticOverflow)?;
         require_gte!(max_nav, nav, SolvError::InvalidNAVValue);
         require_gte!(nav, min_nav, SolvError::InvalidNAVValue);
+        require_gte!(nav, ONE_BITCOIN, SolvError::InvalidNAVValue);
         let slot = Clock::get()?;
         // Check 24-hour update frequency limit
         require_gte!(slot.unix_timestamp, self.oracle_updated + FREEZE_PERIOD , SolvError::NavUpdateTooFrequent);

--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::{borsh::de, *};
 
-use crate::{constants::{MAX_FEE, ONE_BITCOIN, FREEZE_PERIOD}, errors::SolvError};
+use crate::{constants::{MAX_FEE, ONE_BITCOIN, FREEZE_PERIOD, DELTA}, errors::SolvError};
 
 #[account(discriminator = [1])]
 #[derive(InitSpace)]
@@ -177,7 +177,7 @@ impl Vault {
     pub fn set_nav(&mut self, nav: u64) -> Result<()> {
         // Check nav growth/decrease does not exceed 0.05%
         let nav_diff: u64 = u64::try_from(u128::from(self.nav)
-            .checked_mul(5 as u128)
+            .checked_mul(DELTA as u128)
             .ok_or(ProgramError::ArithmeticOverflow)?
             .checked_div(MAX_FEE.into())
             .ok_or(ProgramError::ArithmeticOverflow)?)
@@ -213,7 +213,7 @@ impl Vault {
         Ok((amount, fee))
     }
 
-    pub fn deposit_fee(&self, currency: &Pubkey) -> Result<u16> {
+    pub fn get_deposit_fee(&self, currency: &Pubkey) -> Result<u16> {
         let index = self.deposit_currencies.iter().position(|token| token.mint.eq(currency)).ok_or(SolvError::CurrencyNotFound)?;
         Ok(self.deposit_currencies[index].deposit_fee)
     }

--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -160,7 +160,7 @@ impl Vault {
             .iter()
             .position(|&token| token.mint.eq(&currency))
         {
-            // Shift all elements after the found index up by one position
+            // Shift all elements after the found index down by one position
             for i in index..self.deposit_currencies.len() - 1 {
                 self.deposit_currencies[i] = self.deposit_currencies[i + 1];
             }

--- a/programs/solvbtc/src/state/vault.rs
+++ b/programs/solvbtc/src/state/vault.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::{borsh::de, *};
 
-use crate::{constants::{MAX_FEE, ONE_BITCOIN}, errors::SolvError};
+use crate::{constants::{MAX_FEE, ONE_BITCOIN, FREEZE_PERIOD}, errors::SolvError};
 
 #[account(discriminator = [1])]
 #[derive(InitSpace)]
@@ -40,6 +40,19 @@ impl Vault {
     ) -> Result<()> {
         require_gte!(nav, ONE_BITCOIN, SolvError::InvalidNAVValue);
         require_gte!(MAX_FEE, withdraw_fee, SolvError::InvalidFeeRatio);
+        if admin.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
+        if fee_receiver.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
+        if treasurer.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
+        if oracle_manager.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
+
         *self = Vault {
             admin,
             mint,
@@ -69,35 +82,44 @@ impl Vault {
 
     pub fn transfer_admin(&mut self, admin: Pubkey) -> Result<()> {
         self.admin = admin;
-        self.update()
+        Ok(())
     }
 
     pub fn set_deposit_fee(&mut self, currency: Pubkey, deposit_fee: u16) -> Result<()> {
         require_gte!(MAX_FEE, deposit_fee, SolvError::InvalidFeeRatio);
+        if currency.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
         let index = self.deposit_currencies.iter().position(|token| token.mint.eq(&currency)).ok_or(SolvError::CurrencyNotFound)?;
         self.deposit_currencies[index].deposit_fee = deposit_fee;
-        self.update()
+        Ok(())
     }
 
     pub fn set_withdraw_fee(&mut self, withdraw_fee: u16) -> Result<()> {
         require_gte!(MAX_FEE, withdraw_fee, SolvError::InvalidFeeRatio);
         self.withdraw_fee = withdraw_fee;
-        self.update()
+        Ok(())
     }
 
     pub fn set_fee_receiver(&mut self, fee_receiver: Pubkey) -> Result<()> {
+        if fee_receiver.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
         self.fee_receiver = fee_receiver;
-        self.update()
+        Ok(())
     }
 
     pub fn set_verifier(&mut self, verifier: [u8; 64]) -> Result<()> {
         self.verifier = verifier;
-        self.update()
+        Ok(())
     }
 
     pub fn set_treasurer(&mut self, treasurer: Pubkey) -> Result<()> {
+        if treasurer.eq(&Pubkey::default()) {
+            return Err(SolvError::InvalidAddress.into());
+        }
         self.treasurer = treasurer;
-        self.update()
+        Ok(())
     }
 
     pub fn add_currency(&mut self, mint: Pubkey, deposit_fee: u16) -> Result<()> {
@@ -105,6 +127,7 @@ impl Vault {
         if mint.eq(&Pubkey::default()) {
             return Err(SolvError::InvalidAddress.into());
         }
+        require_gte!(MAX_FEE, deposit_fee, SolvError::InvalidFeeRatio);
         // Find the first empty slot (Pubkey::default())
         if let Some(empty_index) = self
             .deposit_currencies
@@ -119,7 +142,7 @@ impl Vault {
             // Add the currency to the first empty slot
             self.deposit_currencies[empty_index] = WhitelistedToken { mint, deposit_fee };
 
-            self.update()
+            Ok(())
         } else {
             // No empty slots available
             Err(SolvError::CurrencyArrayFull.into())
@@ -127,11 +150,11 @@ impl Vault {
     }
 
     pub fn remove_currency(&mut self, currency: Pubkey) -> Result<()> {
-        // Ensure we are not trying to add a null address
+        // Ensure we are not trying to remove a null address
         if currency.eq(&Pubkey::default()) {
             return Err(SolvError::InvalidAddress.into());
         }
-        // Find the first instance of the currency
+        // Find the currency, if it exists
         if let Some(index) = self
             .deposit_currencies
             .iter()
@@ -144,7 +167,7 @@ impl Vault {
             // Set the last element to default (empty)
             self.deposit_currencies[self.deposit_currencies.len() - 1] = WhitelistedToken::default();
             
-            self.update()
+            Ok(())
         } else {
             // Currency not found
             Err(SolvError::CurrencyNotFound.into())
@@ -164,13 +187,17 @@ impl Vault {
         let min_nav = self.nav.checked_sub(nav_diff).ok_or(ProgramError::ArithmeticOverflow)?;
         require_gte!(max_nav, nav, SolvError::InvalidNAVValue);
         require_gte!(nav, min_nav, SolvError::InvalidNAVValue);
+        let slot = Clock::get()?;
+        // Check 24-hour update frequency limit
+        require_gte!(slot.unix_timestamp, self.oracle_updated + FREEZE_PERIOD , SolvError::NavUpdateTooFrequent);
+
         self.nav = nav;
         self.update()
     }
 
     pub fn set_oracle_manager(&mut self, manager: Pubkey) -> Result<()> {
         self.oracle_manager = manager;
-        self.update()
+        Ok(())
     }
 
     pub fn calculate_fee(amount: u64, fee: u16) -> Result<(u64, u64)> {

--- a/programs/solvbtc/src/state/withdraw_request_v2.rs
+++ b/programs/solvbtc/src/state/withdraw_request_v2.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use solana_secp256k1::UncompressedPoint;
-use solana_secp256k1_ecdsa::{hash::sha256::Sha256, Secp256k1EcdsaSignature, hash::keccak::Keccak};
+use solana_secp256k1_ecdsa::{Secp256k1EcdsaSignature, hash::keccak::Keccak};
 use const_crypto::bs58::{encode_pubkey};
 
 use crate::events::WithdrawRequestEventV2;

--- a/programs/solvbtc/src/state/withdraw_request_v2.rs
+++ b/programs/solvbtc/src/state/withdraw_request_v2.rs
@@ -1,0 +1,89 @@
+use anchor_lang::prelude::*;
+use solana_secp256k1::UncompressedPoint;
+use solana_secp256k1_ecdsa::{hash::sha256::Sha256, Secp256k1EcdsaSignature, hash::keccak::Keccak};
+use const_crypto::bs58::{encode_pubkey};
+
+use crate::events::WithdrawRequestEventV2;
+
+#[account(discriminator = [4])]
+#[derive(InitSpace)]
+pub struct WithdrawRequestV2 {
+    pub user: Pubkey,
+    pub withdraw_token_account: Pubkey,
+    pub withdraw_token: Pubkey,
+    pub withdraw_amount: u64,
+    pub token: Pubkey,
+    pub shares: u64,
+    pub request_hash: [u8; 32],
+    pub nav: u64,
+    pub slot: u64
+}
+
+impl WithdrawRequestV2 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn initialize(
+        &mut self,
+        user: Pubkey,
+        withdraw_token_account: Pubkey,
+        withdraw_token: Pubkey,
+        withdraw_amount: u64,
+        token: Pubkey,
+        shares: u64,
+        request_hash: [u8; 32],
+        nav: u64,
+    ) -> Result<()> {
+        let clock = Clock::get()?;
+        let slot = clock.slot;
+
+        *self = WithdrawRequestV2 {
+            user,
+            withdraw_token_account,
+            withdraw_token,
+            withdraw_amount,
+            token,
+            shares,
+            request_hash,
+            nav,
+            slot,
+        };
+
+        // Emit initialize event
+        emit!(WithdrawRequestEventV2 {
+            user,
+            withdraw_token,
+            withdraw_amount,
+            token,
+            shares,
+            request_hash,
+            nav,
+            slot
+        });
+
+        Ok(())
+    }
+
+    pub fn verify_eip191(&self, signature: Secp256k1EcdsaSignature, verifier: [u8;64]) -> Result<()>{
+        Ok(signature
+            .normalize_s()
+            .verify::<Keccak, UncompressedPoint>(&self.eip191_msg(), UncompressedPoint(verifier))
+            .map_err(|_| ProgramError::MissingRequiredSignature)?)
+    }
+
+    pub fn concat(&self) -> String {
+        let data = self.user.to_string() + "\n" +
+        self.withdraw_token.to_string().as_str() + "\n" +
+        encode_pubkey(&self.request_hash).str() + "\n" +
+        &self.shares.to_string() + "\n" +
+        &self.nav.to_string() + "\n" +
+        &self.slot.to_string();
+        data
+    }
+
+    pub fn eip191_msg(&self) -> Vec<u8>{
+        let message_prefix = "\x19Ethereum Signed Message:\n";
+        let data = self.concat();
+        let length= data.len().to_string();
+        let full_msg = message_prefix.to_string() + &length + &data;
+        full_msg.as_bytes().to_vec()
+    }
+}

--- a/programs/solvbtc/src/state/withdraw_request_v2.rs
+++ b/programs/solvbtc/src/state/withdraw_request_v2.rs
@@ -16,7 +16,7 @@ pub struct WithdrawRequestV2 {
     pub shares: u64,
     pub request_hash: [u8; 32],
     pub nav: u64,
-    pub slot: u64
+    pub mint: Pubkey
 }
 
 impl WithdrawRequestV2 {
@@ -31,9 +31,8 @@ impl WithdrawRequestV2 {
         shares: u64,
         request_hash: [u8; 32],
         nav: u64,
+        mint: Pubkey
     ) -> Result<()> {
-        let clock = Clock::get()?;
-        let slot = clock.slot;
 
         *self = WithdrawRequestV2 {
             user,
@@ -44,7 +43,7 @@ impl WithdrawRequestV2 {
             shares,
             request_hash,
             nav,
-            slot,
+            mint,
         };
 
         // Emit initialize event
@@ -56,7 +55,7 @@ impl WithdrawRequestV2 {
             shares,
             request_hash,
             nav,
-            slot
+            mint
         });
 
         Ok(())
@@ -75,7 +74,7 @@ impl WithdrawRequestV2 {
         encode_pubkey(&self.request_hash).str() + "\n" +
         &self.shares.to_string() + "\n" +
         &self.nav.to_string() + "\n" +
-        &self.slot.to_string();
+        &self.mint.to_string();
         data
     }
 

--- a/sdk/solvbtc.ts
+++ b/sdk/solvbtc.ts
@@ -86,10 +86,10 @@ export function deriveWithdrawRequestSigningHash(user: PublicKey, mint: PublicKe
   ]))
 }
 
-export function deriveWithdrawRequestEip191(user: PublicKey, mint: PublicKey, hash: Uint8Array, share:BN, nav: BN, slot:BN): Uint8Array{
+export function deriveWithdrawRequestEip191(user: PublicKey, mint: PublicKey, hash: Uint8Array, share:BN, nav: BN, vaultMint:PublicKey): Uint8Array{
   let prefix = "\x19Ethereum Signed Message:\n";
   let msg = user.toBase58() +"\n" + mint.toBase58() +"\n" + bs58.encode(hash) + "\n" 
-  + Number(share).toString() + "\n" + Number(nav).toString() +"\n" + Number(slot).toString();
+  + Number(share).toString() + "\n" + Number(nav).toString() +"\n" + vaultMint.toBase58();
   let eip191Msg = prefix + msg.length.toString() + msg;
   console.log(eip191Msg);
   return Buffer.from(eip191Msg);

--- a/sdk/solvbtc.ts
+++ b/sdk/solvbtc.ts
@@ -86,10 +86,10 @@ export function deriveWithdrawRequestSigningHash(user: PublicKey, mint: PublicKe
   ]))
 }
 
-export function deriveWithdrawRequestEip191(user: PublicKey, mint: PublicKey, hash: Uint8Array, share:BN, nav: BN): Uint8Array{
+export function deriveWithdrawRequestEip191(user: PublicKey, mint: PublicKey, hash: Uint8Array, share:BN, nav: BN, slot:BN): Uint8Array{
   let prefix = "\x19Ethereum Signed Message:\n";
   let msg = user.toBase58() +"\n" + mint.toBase58() +"\n" + bs58.encode(hash) + "\n" 
-  + Number(share).toString() + "\n" + Number(nav).toString();
+  + Number(share).toString() + "\n" + Number(nav).toString() +"\n" + Number(slot).toString();
   let eip191Msg = prefix + msg.length.toString() + msg;
   console.log(eip191Msg);
   return Buffer.from(eip191Msg);

--- a/tests/solvbtc.ts
+++ b/tests/solvbtc.ts
@@ -643,6 +643,7 @@ describe("solvbtc", () => {
   });
 
   it("Set and Check NAV", async () => {
+
     const tx = await program.methods.vaultSetNav(
       ONE_BITCOIN
     )
@@ -794,7 +795,7 @@ describe("solvbtc", () => {
     }).instruction();
 
     const tx = new Transaction();
-    tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
+    tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 400_000 }));
     tx.add(ix);
     await sendAndConfirmTransaction(connection, tx, [userKeypair]);
 

--- a/tests/solvbtc.ts
+++ b/tests/solvbtc.ts
@@ -773,7 +773,7 @@ describe("solvbtc", () => {
       hash,
       withdrawRequestData.shares,
       withdrawRequestData.nav,
-      withdrawRequestData.slot,
+      withdrawRequestData.mint,
     )
 
     const signature = createEip191WithdrawSig(

--- a/tests/solvbtc.ts
+++ b/tests/solvbtc.ts
@@ -765,7 +765,7 @@ describe("solvbtc", () => {
   })
 
   it("Process withdraw request", async () => {
-    const withdrawRequestData = await program.account.withdrawRequest.fetch(withdrawRequest);
+    const withdrawRequestData = await program.account.withdrawRequestV2.fetch(withdrawRequest);
 
     const verifierHash = deriveWithdrawRequestEip191(
       user,
@@ -773,13 +773,14 @@ describe("solvbtc", () => {
       hash,
       withdrawRequestData.shares,
       withdrawRequestData.nav,
+      withdrawRequestData.slot,
     )
 
     const signature = createEip191WithdrawSig(
       verifierKeypair,
       verifierHash
     )
-    const ix = await program.methods.vaultWithdraw(
+    const ix = await program.methods.vaultWithdrawV2(
       Array.from(hash),
       signature.signature
     )


### PR DESCRIPTION
The vault uses hash(user, withdraw_token, request_hash, shares, nav) to distinguish each redemption, but different vaults might have the same hash. This would allow a user to use a request from vault 1 to withdraw funds from vault 2.
